### PR TITLE
Fix mapping of TileProvider.NO_TILE

### DIFF
--- a/maps-wrapper/src/main/java/maps/wrapper/TileProvider.java
+++ b/maps-wrapper/src/main/java/maps/wrapper/TileProvider.java
@@ -1,6 +1,8 @@
 package maps.wrapper;
 
 public interface TileProvider {
-    Tile NO_TILE = new Tile(null  , null);
+    Tile NO_TILE = new Tile(com.google.android.gms.maps.model.TileProvider.NO_TILE,
+                            com.huawei.hms.maps.model.TileProvider.NO_TILE);
+
     Tile getTile(int x, int y, int zoom);
 }


### PR DESCRIPTION
When a TileProvider does not want to provide a tile for specific
coordinates, it returns NO_TILE. The mapping layer was passing on null
in that case, which is the signal for an error and will result in a
retry. The mapping layer was updated to use the GMS/HMS versions of
NO_TILE instead of null.